### PR TITLE
Add Tau (τ) support - Bugzilla #757093

### DIFF
--- a/lib/mpfr.vapi
+++ b/lib/mpfr.vapi
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Daniel Renninghoff
+ * Copyright (C) 2014-2015 Daniel Renninghoff
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -82,7 +82,16 @@ namespace MPFR {
         public double get_double (Round rnd);
 
         public int const_pi (Round rnd);
-	public int const_tau (Round rnd);
+
+        [CCode (cname="mpfr_mul_2ui")]
+        public int multiply_power_of_2 (MPFloat op1, long op2, Round rnd);
+
+        public int const_tau (Round rnd) {
+            int i = const_pi (rnd);
+            multiply_power_of_2 (this, 1, rnd);
+            return i;
+        }
+
         [CCode (cname="mpfr_zero_p")]
         public bool is_zero ();
         public int sgn ();

--- a/lib/mpfr.vapi
+++ b/lib/mpfr.vapi
@@ -82,6 +82,7 @@ namespace MPFR {
         public double get_double (Round rnd);
 
         public int const_pi (Round rnd);
+	public int const_tau (Round rnd);
         [CCode (cname="mpfr_zero_p")]
         public bool is_zero ();
         public int sgn ();

--- a/lib/number.vala
+++ b/lib/number.vala
@@ -156,6 +156,16 @@ public class Number : Object
         im_num = tmp2;
     }
 
+    public Number.tau ()
+    {
+        var tmp = MPFloat.init2 ((Precision) precision);
+        tmp.const_tau (Round.NEAREST);
+        re_num = tmp;
+        var tmp2 = MPFloat.init2 ((Precision) precision);
+        tmp2.set_unsigned_integer (0, Round.NEAREST);
+        im_num = tmp2;
+    }
+
     /* Sets z to be a uniform random number in the range [0, 1] */
     public Number.random ()
     {

--- a/src/math-buttons.vala
+++ b/src/math-buttons.vala
@@ -290,7 +290,8 @@ public class MathButtons : Gtk.Box
         /* Configure buttons */
         /* Tooltip for the Pi button */
         setup_button (builder, "pi", "π", _("Pi [Ctrl+P]"));
-        /* Tooltip for the Euler's Number button */
+        setup_button (builder, "tau", "τ", _("Tau [Ctrl+T]"));
+	/* Tooltip for the Euler's Number button */
         setup_button (builder, "eulers_number", "e", _("Euler’s Number"));
         setup_button (builder, "imaginary", "i", null);
         setup_button (builder, "numeric_point", null, null);

--- a/src/math-display.vala
+++ b/src/math-display.vala
@@ -254,6 +254,9 @@ public class MathDisplay : Gtk.Viewport
             case Gdk.Key.p:
                 equation.insert ("π");
                 return true;
+	    case Gdk.Key.t:
+                equation.insert ("τ");
+                return true;
             case Gdk.Key.r:
                 equation.insert ("√");
                 return true;

--- a/tests/test-number.vala
+++ b/tests/test-number.vala
@@ -153,7 +153,7 @@ private void test_pi ()
 private void test_tau ()
 {
     var z = new Number.tau ();
-    var expected = Math.TAU;
+    var expected = Math.PI * 2.0;
     if (!double_matches (z, expected))
     {
         fail ("Number.tau () -> %f, expected %f".printf (z.to_double (), expected));
@@ -1094,6 +1094,7 @@ static int main (string[] args)
     test_eulers ();
     test_i ();
     test_pi ();
+    test_tau ();
     //test_random ();
     test_is_zero ();
     test_is_negative ();

--- a/tests/test-number.vala
+++ b/tests/test-number.vala
@@ -150,6 +150,19 @@ private void test_pi ()
     pass ();
 }
 
+private void test_tau ()
+{
+    var z = new Number.tau ();
+    var expected = Math.TAU;
+    if (!double_matches (z, expected))
+    {
+        fail ("Number.tau () -> %f, expected %f".printf (z.to_double (), expected));
+        return;
+    }
+
+    pass ();
+}
+
 private void test_eulers ()
 {
     var z = new Number.eulers ();


### PR DESCRIPTION
This is a first attempt to add Tau support in bug [Bugzilla #757093](https://bugzilla.gnome.org/show_bug.cgi?id=757093).

It requires low level support from MPFR library since the const are fetched via [mpfr.h](http://www.mpfr.org) and MPFR trunk doesn't implement still this feature.

See the example for [const_pi](https://gforge.inria.fr/scm/viewvc.php/mpfr/trunk/src/const_pi.c?revision=9684&view=markup)

We need the same for const_tau in [MPFR trunk](https://gforge.inria.fr/scm/viewvc.php/mpfr/trunk/src/)
