### PR TITLE
Fix #748743: keyboard mode without focus

### DIFF
--- a/src/math-window.vala
+++ b/src/math-window.vala
@@ -107,9 +107,9 @@ public class MathWindow : Gtk.ApplicationWindow
         scrolled_window.show ();
 
         _display = new MathDisplay (equation);
-        _display.grabfocus ();
         scrolled_window.add (display);
         display.show ();
+        display.grabfocus();
 
         _buttons = new MathButtons (equation);
 


### PR DESCRIPTION
In keyboard mode, calculator initially doesn't get the focus. This fixes this.