### PR TITLE
Period key on numpad will now work.

### DIFF
--- a/src/math-display.vala
+++ b/src/math-display.vala
@@ -185,6 +185,9 @@ public class MathDisplay : Gtk.Viewport
         case Gdk.Key.KP_Page_Up:
             new_keyval = Gdk.Key.@9;
             break;
+		case Gdk.Key.KP_Delete:
+			new_keyval = Gdk.Key.period;
+			break;
         }
 
         if (new_keyval != 0)

--- a/src/math-display.vala
+++ b/src/math-display.vala
@@ -185,9 +185,9 @@ public class MathDisplay : Gtk.Viewport
         case Gdk.Key.KP_Page_Up:
             new_keyval = Gdk.Key.@9;
             break;
-		case Gdk.Key.KP_Delete:
-			new_keyval = Gdk.Key.period;
-			break;
+        case Gdk.Key.KP_Delete:
+            new_keyval = Gdk.Key.period;
+            break;
         }
 
         if (new_keyval != 0)


### PR DESCRIPTION
I'm not sure why this was left out for so long. The Home, End, PgUp, PgDown, Ins and '5' keys all behave as if NumLock is off, regardless of whether or not it is. 

I've added to this the 'delete' key on the numpad so that it correctly acts as a period/decimal point.